### PR TITLE
Get concepts by in_scheme property

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,9 +15,9 @@ munch==2.5.0
 owlrl==5.2.1
 pyldapi==2.1.4
 pyparsing==2.4.7
-PyYAML==5.4
+PyYAML
 rdflib==5.0.0
-rdflib-jsonld==0.5.0
+rdflib-jsonld==0.6.1
 requests==2.25.1
 six==1.14.0
 soupsieve==2.0

--- a/skos/__init__.py
+++ b/skos/__init__.py
@@ -332,7 +332,6 @@ def get_concept_hierarchy_collection(uri):
 def get_concept_hierarchy(uri):
     hierarchy = ''
     top_concepts = []
-
     for top_concept in Config.g.objects(URIRef(uri), SKOS.hasTopConcept):
         if not is_deprecated(top_concept):
             label = get_label(top_concept)
@@ -438,6 +437,16 @@ def member_of(uri):
         label = get_label(collection)
         collections.append((collection, label))
     return collections
+
+def subjects(uri):
+    """
+    which subjects are in scheme?
+    """
+    subjects = []
+    for sj in Config.g.subjects(SKOS.inScheme, URIRef(uri)):
+        label = get_label(sj)
+        subjects.append((sj, label))
+    return subjects
 
 
 def get_creator(uri):

--- a/skos/common_properties.py
+++ b/skos/common_properties.py
@@ -16,4 +16,5 @@ class CommonPropertiesMixin:
         self.bibliographic_citation = skos.get_bibliographic_citation(uri)
         self.is_defined_by = skos.get_is_defined_by(uri)
         self.collections = skos.member_of(uri)
+        self.subjects = skos.subjects(uri)
         self.source = skos.get_dcterms_source(uri)

--- a/templates/skos.html
+++ b/templates/skos.html
@@ -74,7 +74,7 @@
 
             {{ render_definition(c.definition) }}
 
-            {{ render_members(c.skos_members) }}
+            {{ render_members(c.skos_members or c.subjects) }}
 
             {{ render_is_defined_by(c.is_defined_by) }}
 


### PR DESCRIPTION
this is a draft PR, just to test some ideas

In [our skos.ttl](https://github.com/glosis-ld/glosis/blob/master/glosis_cl.ttl) we don't have collections and member references, only conceptscheme and concept.in_scheme (which causes in_scheme concepts not to be displayed)

This PR adds a selection of in_scheme concepts to be presented as members of a concept scheme

It also updates 2 dependencies to get things running locally

I can update the PR to fit with your needs, if you can provide some guidance on how to improve (for example, use in_scheme only if collections are empty)